### PR TITLE
Dockerize the monitor script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:2.7-slim
+
+ADD . /app
+
+RUN useradd -u 10106 -r -s /bin/false monitor
+RUN chmod 755 /app/bin/entrypoint.sh
+
+USER monitor
+
+ENTRYPOINT [ "/app/bin/entrypoint.sh" ]

--- a/Grafana/elasticsearch2elastic.py
+++ b/Grafana/elasticsearch2elastic.py
@@ -8,12 +8,12 @@ import os
 import sys
 
 # ElasticSearch Cluster to Monitor
-elasticServer = "http://server1:9200"
+elasticServer = os.environ.get('ES_METRICS_CLUSTER_URL', 'http://server1:9200')
 interval = 60
 
 # ElasticSearch Cluster to Send Metrics
-elasticIndex = "elasticsearch_metrics"
-elasticMonitoringCluster = "http://server2:9200"
+elasticIndex = os.environ.get('ES_METRICS_INDEX_NAME', 'elasticsearch_metrics')
+elasticMonitoringCluster = os.environ.get('ES_METRICS_MONITORING_CLUSTER_URL', 'http://server2:9200')
 
 
 def fetch_clusterhealth():

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+REPO_BASE=$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )
+
+/usr/local/bin/python ${REPO_BASE}/Grafana/elasticsearch2elastic.py


### PR DESCRIPTION
See commit comments for change description.

To build the container:

```bash
git clone https://github.com/trevorndodds/Python.git es-monitor
cd es-monitor
docker build -t trinitronx/es-monitor:latest .
```

To run it:

```bash
docker run -d -e ES_METRICS_CLUSTER_URL=http://search1.example.net:9200 \
-e ES_METRICS_INDEX_NAME=elasticsearch_metrics-search1 \
-e ES_METRICS_MONITORING_CLUSTER_URL=http://es-monitor.example.net:9200 \
trinitronx/es-monitor:latest
```